### PR TITLE
Update metainfo.xml

### DIFF
--- a/application/com.vicr123.thebeat.metainfo.xml
+++ b/application/com.vicr123.thebeat.metainfo.xml
@@ -7,7 +7,9 @@
   
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  <developer_name>Victor Tran</developer_name>
+  <developer id="com.vicr123">
+    <name>Victor Tran</name>
+  </developer>
   
   <recommends>
     <control>pointing</control>
@@ -40,7 +42,7 @@
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
   
-  <url type="homepage">http://vicr123.com/</url>
+  <url type="homepage">https://vicr123.com/</url>
   <url type="help">https://help.vicr123.com/docs/thebeat/intro</url>
   <url type="translate">https://translate.vicr123.com/projects/thebeat/</url>
   


### PR DESCRIPTION
### Use https to fix a appstreamcli warning

> url-not-secure http://vicr123.com/
> Consider using a secure (HTTPS) URL for this web link.

### Update developer_name tag

> The toplevel `developer_name` element is deprecated. Please use the `name` element in a `developer` block instead.